### PR TITLE
fix deprecated functions

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -36,7 +36,8 @@ Imports: assertthat,
     tidyr (>= 1.3.0),
     usethis (>= 2.1.6),
     rlang (>= 1.0.6),
-    base64enc (>= 0.1)
+    base64enc (>= 0.1),
+    rstudioapi (>=0.14)
 Remotes:
     https://github.com/r-lib/gargle
 RoxygenNote: 7.2.3

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: chchpd
 Type: Package
 Title: Manage and Manipulate Christchurch Parkinson's Studies Data
-Version: 0.5.2
+Version: 0.5.3
 Authors@R: c(
     person('Michael', 'MacAskill', email = 'michael.macaskill@nzbri.org', 
     role = c('cre')),
@@ -23,8 +23,8 @@ Imports: assertthat,
     dplyr (>= 1.0.10),
     gargle (> 1.2.1),
     ggplot2 (>= 3.3.6),
-    googlesheets4 (>= 1.0.1),
-    googledrive (>= 2.0.0),
+    googlesheets4 (>= 1.1.0),
+    googledrive (>= 2.1.0),
     httpuv (>= 1.6.8),
     janitor (>= 2.1.0),
     knitr (>= 1.42),
@@ -39,6 +39,6 @@ Imports: assertthat,
     base64enc (>= 0.1)
 Remotes:
     https://github.com/r-lib/gargle
-RoxygenNote: 7.2.1
+RoxygenNote: 7.2.3
 Depends: 
     R (>= 4.0.2)

--- a/R/chchpd.R
+++ b/R/chchpd.R
@@ -79,8 +79,8 @@ chchpd_env$cached <- list() # store imported dataframes here by name
   # Configure googledrive and googlesheets to use CHCHPD application. This
   # improves issues related to exhausting Google's resources.
   # Currently, this only allows @nzbri.org email addresses to login.
-  invisible(googlesheets4::gs4_auth_configure(app = chchpd_oauth_app(use_server=chchpd_check_rstudio_server())))
-  invisible(googledrive::drive_auth_configure(app = chchpd_oauth_app(use_server=chchpd_check_rstudio_server())))
+  invisible(googlesheets4::gs4_auth_configure(client = chchpd_oauth_app(use_server=chchpd_check_rstudio_server())))
+  invisible(googledrive::drive_auth_configure(client = chchpd_oauth_app(use_server=chchpd_check_rstudio_server())))
 
   invisible()
 }

--- a/R/chchpd_auth.R
+++ b/R/chchpd_auth.R
@@ -46,8 +46,8 @@ chchpd_oauth_app <- function(use_server=NULL) {
 
 #' Check whether RStudio is running in server mode:
 chchpd_check_rstudio_server <- function(){
-  check_server <- try(rstudioapi::versionInfo()$mode == 'server', silent = TRUE)
-  if(length(check_server) == 0 || is(check_server, 'try-error')){
+  check_server <- TRUE
+  if(rstudioapi::isAvailable() && (rstudioapi::versionInfo()$mode != 'server')){
     check_server <- FALSE
   }
   invisible(check_server)

--- a/R/import_data.R
+++ b/R/import_data.R
@@ -302,8 +302,8 @@ get_googlesheet_modifiedtime <- function(dataset) {
 google_authenticate <- function(email = chchpd_user(),
                                 use_server = chchpd_check_rstudio_server()) {
   
-  invisible(googlesheets4::gs4_auth_configure(app = chchpd_oauth_app(use_server)))
-  invisible(googledrive::drive_auth_configure(app = chchpd_oauth_app(use_server)))
+  invisible(googlesheets4::gs4_auth_configure(client = chchpd_oauth_app(use_server)))
+  invisible(googledrive::drive_auth_configure(client = chchpd_oauth_app(use_server)))
   
   googlesheets4::gs4_auth(email = email,
                           scopes = c("https://www.googleapis.com/auth/spreadsheets.readonly",


### PR DESCRIPTION
Update `googlesheets` and `googledrive` packages and update their associated deprecated functions. Fixes #19 
